### PR TITLE
Added the body of the request to the context

### DIFF
--- a/lib/_http_context.dart
+++ b/lib/_http_context.dart
@@ -7,6 +7,7 @@ class _HttpContext extends Stream<List<int>> implements HttpContext, HttpRequest
   HttpRequest  req;
   HttpResponse res;
   Map<String,String> _params;
+  Map<String,String> _body;
   String _format;
   Express express;
   bool _closed = false;
@@ -59,6 +60,8 @@ class _HttpContext extends Stream<List<int>> implements HttpContext, HttpRequest
     }
     return _params;
   }
+  
+  Map<String,String> get body => _body;
 
   Future<List<int>> readAsBytes() {
     var completer = new Completer<List<int>>();

--- a/lib/express.dart
+++ b/lib/express.dart
@@ -103,6 +103,7 @@ abstract class HttpContext implements HttpRequest {
   HttpRequest  req;
   HttpResponse res;
   Map<String,String> get params;
+  Map<String,String> get body;
 
   //Read APIs
   String get contentType;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -24,7 +24,7 @@ packages:
   markdown:
     description: markdown
     source: hosted
-    version: "0.5.1"
+    version: "0.7.0"
   matcher:
     description: matcher
     source: hosted


### PR DESCRIPTION
Fixed https://github.com/dartist/express/issues/6 by adding a body property to the context.

``` Dart
var app = new Express()
  ..post('/mail', (ctx) {
    var name = ctx.body['name'];
    var mail = ctx.body['mail'];
  });
```
