### PR TITLE
Added the possibility to add a chain of request handlers for a certain route

### DIFF
--- a/lib/_express.dart
+++ b/lib/_express.dart
@@ -13,7 +13,7 @@ class RequestHandlerEntry {
 String __dirname = Directory.current.toString();
 
 class _Express implements Express {
-  Map<String, LinkedHashMap<String,RequestHandler>> _verbPaths;
+  Map<String, LinkedHashMap<String,Route>> _verbPaths;
   List<String> _verbs = const ["GET","POST","PUT","DELETE","PATCH","HEAD","OPTIONS","ANY"];
   List<Module> _modules;
   HttpServer server;
@@ -22,7 +22,7 @@ class _Express implements Express {
   ErrorHandler errorHandler;
 
   _Express() {
-    _verbPaths = new Map<String, LinkedHashMap<String,RequestHandler>>();
+    _verbPaths = new Map<String, LinkedHashMap<String,Route>>();
     _verbs.forEach((x) => _verbPaths[x] = {});
     _modules = new List<Module>();
     _customHandlers = new List<RequestHandlerEntry>();
@@ -31,19 +31,15 @@ class _Express implements Express {
     config('views', 'views');
   }
 
-  Express _addHandler(String verb, String atRoute, RequestHandler handler){
-    _verbPaths[verb][atRoute] = managedRequestHandler(handler);
-    return this;
-  }
-  
-  managedRequestHandler(RequestHandler handler){
-    return (HttpContext ctx){
-      try {
-        handler(ctx);
-      } catch (e, stacktrace){
-        errorHandler(e, stacktrace, ctx);
-      }
-    };
+  Route _addHandler(String verb, String atRoute, [RequestHandler handler]){
+    var route = new Route(atRoute, errorHandler);
+    
+    if(handler != null) {
+      route.then(handler);
+    }
+    
+    _verbPaths[verb][atRoute] = route;
+    return route;
   }
 
   void config(String name, String value){
@@ -59,29 +55,29 @@ class _Express implements Express {
     return this;
   }
 
-  Express get(String atRoute, RequestHandler handler) =>
+  Route get(String atRoute, [RequestHandler handler]) =>
       _addHandler("GET", atRoute, handler);
 
-  Express post(String atRoute, RequestHandler handler) =>
+  Route post(String atRoute, [RequestHandler handler]) =>
       _addHandler("POST", atRoute, handler);
 
-  Express put(String atRoute, RequestHandler handler) =>
+  Route put(String atRoute, [RequestHandler handler]) =>
       _addHandler("PUT", atRoute, handler);
 
-  Express delete(String atRoute, RequestHandler handler) =>
+  Route delete(String atRoute, [RequestHandler handler]) =>
       _addHandler("DELETE", atRoute, handler);
 
-  Express patch(String atRoute, RequestHandler handler) =>
+  Route patch(String atRoute, [RequestHandler handler]) =>
       _addHandler("PATCH", atRoute, handler);
 
-  Express head(String atRoute, RequestHandler handler) =>
+  Route head(String atRoute, [RequestHandler handler]) =>
       _addHandler("HEAD", atRoute, handler);
 
-  Express options(String atRoute, RequestHandler handler) =>
+  Route options(String atRoute, [RequestHandler handler]) =>
       _addHandler("OPTIONS", atRoute, handler);
 
   // Register a request handler that handles any verb
-  Express any(String atRoute, RequestHandler handler) =>
+  Route any(String atRoute, [RequestHandler handler]) =>
       _addHandler("ANY", atRoute, handler);
 
   void operator []=(String atRoute, RequestHandler handler){
@@ -160,7 +156,7 @@ class _Express implements Express {
                 logDebug("Handling $verb request to $route");
                 var handler = handlers[route];
                 ctx = new HttpContext(this, req, route);
-                handler(ctx);
+                handler.handle(ctx);
                 return;
               }
             }            

--- a/lib/_route.dart
+++ b/lib/_route.dart
@@ -1,0 +1,38 @@
+part of express;
+
+class _Route implements Route {
+  
+  String atRoute;
+  ErrorHandler errorHandler;
+  Queue<RequestHandler> handlers;
+  
+  _Route(this.atRoute, this.errorHandler) {
+    handlers = new Queue<RequestHandler>();
+  }
+  
+  Route then(RequestHandler handler) {
+    handlers.add(managedRequestHandler(handler));
+    
+    return this;
+  }
+  
+  void handle(HttpContext ctx) {
+    bool result = true;
+    
+    while(handlers.length > 0 && result) {
+      RequestHandler handler = handlers.removeFirst();
+      
+      result = handler(ctx);
+    }
+  }
+  
+  managedRequestHandler(RequestHandler handler){
+    return (HttpContext ctx){
+      try {
+        return handler(ctx);
+      } catch (e, stacktrace){
+        errorHandler(e, stacktrace, ctx);
+      }
+    };
+  }
+}

--- a/lib/express.dart
+++ b/lib/express.dart
@@ -14,6 +14,7 @@ import "package:ansicolor/ansicolor.dart" as ansicolor;
 part "content_types.dart";
 part "_express.dart";
 part "_http_context.dart";
+part "_route.dart";
 part "utils.dart";
 
 part "modules/static_file_handler.dart";
@@ -42,28 +43,28 @@ abstract class Express {
   Express use(Module module);
 
   //Register a request handler that will be called for a matching GET request
-  Express get(String atRoute, RequestHandler handler);
+  Route get(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that will be called for a matching POST request
-  Express post(String atRoute, RequestHandler handler);
+  Route post(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that will be called for a matching PUT request
-  Express put(String atRoute, RequestHandler handler);
+  Route put(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that will be called for a matching DELETE request
-  Express delete(String atRoute, RequestHandler handler);
+  Route delete(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that will be called for a matching PATCH request
-  Express patch(String atRoute, RequestHandler handler);
+  Route patch(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that will be called for a matching HEAD request
-  Express head(String atRoute, RequestHandler handler);
+  Route head(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that will be called for a matching OPTIONS request
-  Express options(String atRoute, RequestHandler handler);
+  Route options(String atRoute, [RequestHandler handler]);
 
   //Register a request handler that handles ANY verb
-  Express any(String atRoute, RequestHandler handler);
+  Route any(String atRoute, [RequestHandler handler]);
   
   //Register a custom request handler. Execute requestHandler, if matcher is true.
   //If priority < 0, custom handler will be executed before route handlers, otherwise after. 
@@ -140,8 +141,14 @@ abstract class HttpContext implements HttpRequest {
   bool get closed;
 }
 
+abstract class Route {
+  factory Route(String atRoute, ErrorHandler errorHandler) => new _Route(atRoute, errorHandler);
+  
+  Route then(RequestHandler handler);
+}
+
 // The signature your Request Handlers should implement
-typedef void RequestHandler (HttpContext ctx);
+typedef RequestHandler (HttpContext ctx);
 
 // Register different Formatters
 abstract class Formatter implements Module {

--- a/lib/express.dart
+++ b/lib/express.dart
@@ -141,9 +141,12 @@ abstract class HttpContext implements HttpRequest {
   bool get closed;
 }
 
+/* This class is used to chain a queue of request handlers to a certain route.
+ */
 abstract class Route {
   factory Route(String atRoute, ErrorHandler errorHandler) => new _Route(atRoute, errorHandler);
   
+  // Register a new handler at the back of the queue
   Route then(RequestHandler handler);
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -24,7 +24,7 @@ packages:
   markdown:
     description: markdown
     source: hosted
-    version: "0.5.1"
+    version: "0.7.0"
   matcher:
     description: matcher
     source: hosted


### PR DESCRIPTION
As described in https://github.com/dartist/express/issues/16 I added the possibility to register a chain of request handlers. This allows the developer to use little pieces of middleware.

``` Dart
// Controllers
HomeController home = new HomeController();

// Middlewares
AuthMiddleware auth = new AuthMiddleware();

var app = new Express();
// The old way but still working with this update
app.get('/', home.index);

// The way it could be done with middleware
app.get('/users').then(auth.isSignedIn).then(home.users);
```

Because of the changes, it's not possible to chain them like this

``` Dart
var app = new Express();
app.get('/', home.index)
     ..get('/users', home.users);
```

If this pull request is accepted, I will update the README documentation.
